### PR TITLE
Add client-side binding SQL helpers for DDL statements

### DIFF
--- a/misc/python/materialize/cloudtest/util/sql.py
+++ b/misc/python/materialize/cloudtest/util/sql.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import Any, List, Optional, Sequence
+from typing import Any, List, LiteralString, Optional, Sequence
 
 import psycopg
 from psycopg.connection import Connection
@@ -20,7 +20,7 @@ from materialize.cloudtest.util.web_request import post
 
 def sql_query(
     conn: Connection[Any],
-    query: str,
+    query: LiteralString,
     vars: Optional[Sequence[Any]] = None,
 ) -> List[List[Any]]:
     cur = conn.cursor()
@@ -30,10 +30,29 @@ def sql_query(
 
 def sql_execute(
     conn: Connection[Any],
-    query: str,
+    query: LiteralString,
     vars: Optional[Sequence[Any]] = None,
 ) -> None:
     cur = conn.cursor()
+    cur.execute(query, vars)
+
+
+def sql_query_ddl(
+    conn: Connection[Any],
+    query: LiteralString,
+    vars: Optional[Sequence[Any]] = None,
+) -> List[List[Any]]:
+    cur = psycopg.ClientCursor(conn)
+    cur.execute(query, vars)
+    return [list(row) for row in cur]
+
+
+def sql_execute_ddl(
+    conn: Connection[Any],
+    query: LiteralString,
+    vars: Optional[Sequence[Any]] = None,
+) -> None:
+    cur = psycopg.ClientCursor(conn)
     cur.execute(query, vars)
 
 


### PR DESCRIPTION
Adds SQL helpers that use client-side binding for use with DDL statements. Psycopg 3 uses server-side binding by default, which can't be used for DDL.

### Motivation


  * This PR fixes a previously unreported bug.
The upgrade from psycopg2 broke downstream tests in the cloud repo.
https://github.com/MaterializeInc/cloud/actions/runs/5942092236/job/16115041339
https://www.psycopg.org/psycopg3/docs/basic/from_pg2.html

### Tips for reviewer

Related temporary fix for the cloud repo https://github.com/MaterializeInc/cloud/pull/7278, until we can get this merged.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  I'll make the PR after this is merged. We need to bump the submodule and import these new functions.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  no user-facing behavior changes.
