### PR TITLE
Clarify build_info help for worktree behavior

### DIFF
--- a/src/build-info/src/lib.rs
+++ b/src/build-info/src/lib.rs
@@ -98,6 +98,7 @@ macro_rules! build_info {
                            printf "either build from working Git clone " >&2
                            printf "(see https://materialize.com/docs/install/#build-from-source), " >&2
                            printf "or specify SHA manually by setting MZ_DEV_BUILD_SHA environment variable" >&2
+                           printf "If you are using git worktrees, you must be in the primary worktree." >&2
                            exit 1
                        }
                    fi"#


### PR DESCRIPTION
Clarifies that if the `build_info!` macro cannot determine the git SHA, that if you are using worktrees, you must be on the primary worktree.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Clarifies an error message for developers.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  -  no user-facing behavior changes.
