### PR TITLE
orchestratord rename objects

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -81,7 +81,7 @@ pub mod v1alpha1 {
 
     impl Materialize {
         pub fn backend_secret_name(&self) -> String {
-            format!("materialize-backend-{}", self.name_unchecked())
+            format!("{}-materialize-backend", self.name_unchecked())
         }
 
         pub fn namespace(&self) -> String {
@@ -101,27 +101,27 @@ pub mod v1alpha1 {
         }
 
         pub fn environmentd_statefulset_name(&self, generation: u64) -> String {
-            format!("environmentd-{}-{generation}", self.name_unchecked())
+            format!("{}-environmentd-{generation}", self.name_unchecked())
         }
 
         pub fn environmentd_service_name(&self) -> String {
-            format!("environmentd-{}", self.name_unchecked())
+            format!("{}-environmentd", self.name_unchecked())
         }
 
         pub fn environmentd_generation_service_name(&self, generation: u64) -> String {
-            format!("environmentd-{}-{generation}", self.name_unchecked())
+            format!("{}-environmentd-{generation}", self.name_unchecked())
         }
 
         pub fn balancerd_deployment_name(&self) -> String {
-            format!("balancerd-{}", self.name_unchecked())
+            format!("{}-balancerd", self.name_unchecked())
         }
 
         pub fn balancerd_service_name(&self) -> String {
-            format!("balancerd-{}", self.name_unchecked())
+            format!("{}-balancerd", self.name_unchecked())
         }
 
         pub fn persist_pubsub_service_name(&self, generation: u64) -> String {
-            format!("persist-pubsub-{}-{generation}", self.name_unchecked())
+            format!("{}-persist-pubsub-{generation}", self.name_unchecked())
         }
 
         pub fn name_prefixed(&self, suffix: &str) -> String {


### PR DESCRIPTION
Rename most orchestratord managed objects, to consistently prefix with the Materialize CR name.

### Motivation

Future support for multiple Materialize CRs in a single namespace, and consistency of naming.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
