### PR TITLE
Remove orchestratord name injections

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -81,7 +81,7 @@ pub mod v1alpha1 {
 
     impl Materialize {
         pub fn backend_secret_name(&self) -> String {
-            format!("materialize-backend-{}", self.name_unchecked())
+            "materialize-backend".to_owned()
         }
 
         pub fn namespace(&self) -> String {
@@ -101,31 +101,27 @@ pub mod v1alpha1 {
         }
 
         pub fn environmentd_statefulset_name(&self, generation: u64) -> String {
-            format!("environmentd-{}-{generation}", self.name_unchecked())
+            format!("environmentd-{generation}")
         }
 
         pub fn environmentd_service_name(&self) -> String {
-            format!("environmentd-{}", self.name_unchecked())
+            format!("environmentd")
         }
 
         pub fn environmentd_generation_service_name(&self, generation: u64) -> String {
-            format!("environmentd-{}-{generation}", self.name_unchecked())
+            format!("environmentd-{generation}")
         }
 
         pub fn balancerd_deployment_name(&self) -> String {
-            format!("balancerd-{}", self.name_unchecked())
+            "balancerd".to_owned()
         }
 
         pub fn balancerd_service_name(&self) -> String {
-            format!("balancerd-{}", self.name_unchecked())
+            "balancerd".to_owned()
         }
 
         pub fn persist_pubsub_service_name(&self, generation: u64) -> String {
-            format!("persist-pubsub-{}-{generation}", self.name_unchecked())
-        }
-
-        pub fn name_prefixed(&self, suffix: &str) -> String {
-            format!("{}-{}", self.name_unchecked(), suffix)
+            format!("persist-pubsub-{generation}")
         }
 
         pub fn default_labels(&self) -> BTreeMap<String, String> {

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -340,7 +340,7 @@ fn create_network_policies(
         network_policies.extend([
             // Allow all clusterd/environmentd traffic (within the namespace)
             NetworkPolicy {
-                metadata: mz.managed_resource_meta(mz.name_prefixed("allow-all-within-namespace")),
+                metadata: mz.managed_resource_meta("allow-all-within-namespace".to_owned()),
                 spec: Some(NetworkPolicySpec {
                     egress: Some(vec![NetworkPolicyEgressRule {
                         to: Some(vec![NetworkPolicyPeer {
@@ -369,7 +369,7 @@ fn create_network_policies(
             // Allow traffic from orchestratord to environmentd in order to hit
             // the promotion endpoints during upgrades
             NetworkPolicy {
-                metadata: mz.managed_resource_meta(mz.name_prefixed("allow-orchestratord")),
+                metadata: mz.managed_resource_meta("allow-orchestratord".to_owned()),
                 spec: Some(NetworkPolicySpec {
                     ingress: Some(vec![NetworkPolicyIngressRule {
                         from: Some(vec![NetworkPolicyPeer {
@@ -411,7 +411,7 @@ fn create_network_policies(
             mz.balancerd_service_name(),
         );
         network_policies.extend([NetworkPolicy {
-            metadata: mz.managed_resource_meta(mz.name_prefixed("sql-and-http-ingress")),
+            metadata: mz.managed_resource_meta("sql-and-http-ingress".to_owned()),
             spec: Some(NetworkPolicySpec {
                 ingress: Some(vec![NetworkPolicyIngressRule {
                     from: Some(
@@ -453,7 +453,7 @@ fn create_network_policies(
     }
     if config.network_policies.egress_enabled {
         network_policies.extend([NetworkPolicy {
-            metadata: mz.managed_resource_meta(mz.name_prefixed("sources-and-sinks-egress")),
+            metadata: mz.managed_resource_meta("sources-and-sinks-egress".to_owned()),
             spec: Some(NetworkPolicySpec {
                 egress: Some(vec![NetworkPolicyEgressRule {
                     to: Some(


### PR DESCRIPTION
Remove orchestratord name injections.

### Motivation


  * This PR fixes a previously unreported bug.
 They were inconsistent and based on a user-defined name of the Materialize CR, which could break things if they cause us to violate DNS-1035 rules.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
